### PR TITLE
Allow catch-me to accept a -f argument like mailcatcher so it can be managed by foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ If you need some specific ports just pass them here
 catchme --mailPort 1234 --appPort 4321
 ```
 
+
+If you like running all the things in foreman, pass `true` to --f
+```
+catchme --f true
+```
+
 ## Testing
 
 Running `npm test` will run the unit tests with mocha.

--- a/bin/catch_me
+++ b/bin/catch_me
@@ -5,8 +5,11 @@ var config = require('../dist/lib/config/config.js');
 var forever = require('forever');
 
 process.env.NODE_ENV = 'production';
-forever.startDaemon(__dirname + '/../dist/server.js', {options: process.argv});
-
+if(argv.f === 'true'){
+  forever.start(__dirname + '/../dist/server.js', { options: process.argv });
+} else {
+  forever.startDaemon(__dirname + '/../dist/server.js', {options: process.argv});
+}
 var serverPort = argv.appPort || config.port;
 var mailPort = argv.mailPort || config.mailPort;
 console.log('Send your emails to smtp://127.0.0.1:%s and receive them on http://127.0.0.1:%s', mailPort, serverPort);


### PR DESCRIPTION
I like to run all the things using foreman.

This flag enables that functionality and allows me to use THIS instead of mailcatcher - which I like.  

GREAT job on this project, BTW.
